### PR TITLE
Adding new version site roles

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -25,4 +25,10 @@ description: |-
 - `id` (String) The ID of this resource.
 - `last_updated` (String)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tableau_group.example "group_id"
+```

--- a/docs/resources/group_user.md
+++ b/docs/resources/group_user.md
@@ -26,3 +26,10 @@ description: |-
 - `last_updated` (String)
 
 
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import group_user.example "group_id:user_id"
+```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -30,4 +30,10 @@ description: |-
 - `id` (String) The ID of this resource.
 - `last_updated` (String)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tableau_project.example "project_id"
+```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -28,4 +28,10 @@ description: |-
 - `id` (String) The ID of this resource.
 - `last_updated` (String)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import tableau_user.example "user_id"
+```

--- a/tableau/group_resource.go
+++ b/tableau/group_resource.go
@@ -59,7 +59,10 @@ func (r *groupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					stringvalidator.OneOf([]string{
 						"Creator",
 						"Explorer",
+						"Interactor",
+						"Publisher",
 						"ExplorerCanPublish",
+						"ServerAdministrator",
 						"SiteAdministratorExplorer",
 						"SiteAdministratorCreator",
 						"Unlicensed",

--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -70,7 +70,10 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 					stringvalidator.OneOf([]string{
 						"Creator",
 						"Explorer",
+						"Interactor",
+						"Publisher",
 						"ExplorerCanPublish",
+						"ServerAdministrator",
 						"SiteAdministratorExplorer",
 						"SiteAdministratorCreator",
 						"Unlicensed",


### PR DESCRIPTION
Documentation:
https://help.tableau.com/current/server/en-us/users_site_roles.htm 

For enterprise site_roles don't always equate as a 1 for 1.

Here is an example of what a plan looks like on an imported resource:
```hcl
  # tableau_user.wisely will be updated in-place
  ~ resource "tableau_user" "site_admin" {
      - full_name    = "Wisely (Admin)" -> null
        id           = "xxxxxxxxxxxx"
      + last_updated = (known after apply)
        name         = "siteadmin"
      ~ site_role    = "ServerAdministrator" -> "SiteAdministratorExplorer"
        # (2 unchanged attributes hidden)
    }
 ```
 
 
 Additionally added in some doc examples to be viewable.
 I had to do a bit of digging to find the statements