### PR TITLE
Tableau Server default sites as ""

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,5 +30,5 @@ provider "tableau" {
 - `personal_access_token_secret` (String, Sensitive) Personal access token secret - TABLEAU_PERSONAL_ACCESS_TOKEN_SECRET env var
 - `server_url` (String) URL of your Tableau server - TABLEAU_SERVER_URL env var
 - `server_version` (String) Version of the server identified in URL - TABLEAU_SERVER_VERSION env var
-- `site` (String) Site name from your Tableau URL - TABLEAU_SITE_NAME env var
+- `site` (String) Site name from your Tableau URL - TABLEAU_SITE_NAME env var - for Tableau Server default sites leave as ""
 - `username` (String) Login Username - TABLEAU_USERNAME env var

--- a/tableau/provider.go
+++ b/tableau/provider.go
@@ -217,14 +217,6 @@ func (p *tableauProvider) Configure(ctx context.Context, req provider.ConfigureR
 		)
 	}
 
-	if site == "" {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("site"),
-			"Missing Tableau Site",
-			"Tableau Site must be provided in order to establish a connection",
-		)
-	}
-
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
Tableau Server (vs tableau cloud) accounts have a "default" site, that contains no "site" in the api URL.

https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_auth.htm

> Notes:
> 
> For Tableau Server, to specify the default site, omit contentUrl from the site element, or make the contentUrl value an empty string (contentUrl="").
> For Tableau Cloud, a sign in request must have a site element containing a contentUrl with the value of an existing site. If these are missing, the Sign In request will fail.
> 

I suggest leaving this a parameter to be passed in, but for Tableau Server accounts, the site be able to be left "".

If you have suggestions or would like me to change this let me know.
I have tested locally and am able to run a plan against my default site, as well as my named sites.
Example of my configured provider during testing:


```hcl
provider "tableau" {
    server_url     = "https://mycompany.url.io"
    site           = ""
    server_version = "3.13"
    username       = "xxx"
    password       = "xxx"
}
```