### PR TITLE
Fix deleted users

### DIFF
--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -151,13 +151,10 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-
 	user, err := r.client.GetUser(state.ID.ValueString()) // check to see if user exists
 	if err != nil {
-		user, err = r.client.CreateUser(state.Email.ValueString(), state.Name.ValueString(), state.FullName.ValueString(), state.SiteRole.ValueString(), state.AuthSetting.ValueString())
-		if err != nil {
-			return
-		}
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	state.ID = types.StringValue(user.ID)

--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -151,7 +151,7 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	user, err := r.client.GetUser(state.ID.ValueString()) // check to see if user exists
+	user, err := r.client.GetUser(state.ID.ValueString())
 	if err != nil {
 		resp.State.RemoveResource(ctx)
 		return

--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -153,11 +153,14 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	user, err := r.client.GetUser(state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Tableau User",
-			"Could not read Tableau user ID "+state.ID.ValueString()+": "+err.Error(),
-		)
-		return
+		user, err = r.client.CreateUser(state.Email.ValueString(), state.Name.ValueString(), state.FullName.ValueString(), state.SiteRole.ValueString(), state.AuthSetting.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error re-creating user state",
+				"Could not re-create user, unexpected error: "+err.Error(),
+			)
+			return
+		}
 	}
 
 	state.ID = types.StringValue(user.ID)

--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -151,14 +151,12 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	user, err := r.client.GetUser(state.ID.ValueString())
+
+	user, err := r.client.GetUser(state.ID.ValueString()) // check to see if user exists
 	if err != nil {
+		// user doesn't exist so recreate it and fetch the new ID
 		user, err = r.client.CreateUser(state.Email.ValueString(), state.Name.ValueString(), state.FullName.ValueString(), state.SiteRole.ValueString(), state.AuthSetting.ValueString())
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error re-creating user state",
-				"Could not re-create user, unexpected error: "+err.Error(),
-			)
 			return
 		}
 	}

--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -154,7 +154,6 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	user, err := r.client.GetUser(state.ID.ValueString()) // check to see if user exists
 	if err != nil {
-		// user doesn't exist so recreate it and fetch the new ID
 		user, err = r.client.CreateUser(state.Email.ValueString(), state.Name.ValueString(), state.FullName.ValueString(), state.SiteRole.ValueString(), state.AuthSetting.ValueString())
 		if err != nil {
 			return


### PR DESCRIPTION
Issue: When a user is deleted manually from tableau, either in the case of manual deletion or a database backup; attempting to fetch the user's information via getuser will error out.

Fix: Re-create the user instead of erroring out. This way the terraform state is back in a good spot.

<del>Testing Notes: This will re-create the user during an apply. The reason we have a return during error is because when a new user is created - the ID can't be updated. Therefore, a second apply will cause a create user fail because it hasn't updated the ID (TF is doing GetUser with the old ID). The UpdateUser function doesn't have the ability to update the actual userID nor do I believe the API allows us to do so. We just have to create a new user and overwrite the existing state. During my testing, I couldn't find a case where this would cause an actual issue. <del>


edit: after reading the [terraform plugin framework docs for the Read method](https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations), the following was listed:

- Ignore returning errors that signify the resource is no longer existent, call the response state RemoveResource() method, and return early. The next Terraform plan will recreate the resource.
