### PR TITLE
Verify HTTP response in NewClient

### DIFF
--- a/tableau/client.go
+++ b/tableau/client.go
@@ -75,6 +75,9 @@ func NewClient(server, username, password, personalAccessTokenName, personalAcce
 		}
 
 		body, err := c.doRequest(req)
+		if err != nil {
+			return nil, err
+		}
 
 		// parse response body
 		ar := SignInResponse{}


### PR DESCRIPTION
If we don't check `err` from `c.doRequest()`, we can lose useful information like:
> status: 404, body: {"error":{"summary":"Resource Not Found","detail":"Version '2024.3.0' is not a valid version of the API.","code":"404001"}}