### PR TITLE
[docs] Add 'import' block example into Imports section

### DIFF
--- a/docs/resources/datasource_permission.md
+++ b/docs/resources/datasource_permission.md
@@ -41,8 +41,15 @@ resource "tableau_datasource_permission" "test_permission" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_datasource_permission` using the `datasources`, datasource's id, `permissions`, entity type (`users` or `groups`), entity's id, capability name and capability mode (`Allow` or `Deny`) sepated by slash (`/`). For example:
+```terraform
+import {
+  to = tableau_datasource_permission.example
+  id = "datasources/aaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Connect/Allow"
+}
+```
 
+Using `terraform import`, import `tableau_datasource_permission` using the `datasources`, datasource's id, `permissions`, entity type (`users` or `groups`), entity's id, capability name and capability mode (`Allow` or `Deny`) sepated by slash (`/`). For example:
 ```shell
-terraform import tableau_datasource_permission.example "datasources/<datasource_id>/permissions/<entity_type>/<entity_id>/<capability_name>/<capability_mode>"
+% terraform import tableau_datasource_permission.example "datasources/aaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Connect/Allow"
 ```

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -35,8 +35,15 @@ resource "tableau_group" "example" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_group` using the `id` attribute. For example:
+```terraform
+import {
+  to = tableau_group.example
+  id = "groupaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+}
+```
 
+Using `terraform import`, import `tableau_group` using the `id` attribute. For example:
 ```shell
-terraform import tableau_group.example "group_id"
+% terraform import tableau_group.example groupaaa-bbbb-cccc-dddd-eeeeeeeeeeee
 ```

--- a/docs/resources/group_user.md
+++ b/docs/resources/group_user.md
@@ -34,8 +34,15 @@ resource "tableau_group_user" "example" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `group_user` using the group's and user's `id` separated by a colon (`:`). For example:
+```terraform
+import {
+  to = group_user.example
+  id = "groupida-bbbb-cccc-dddd-eeeeeeeeeeee:userida-bbbb-cccc-dddd-eeeeeeeeeeee"
+}
+```
 
+Using `terraform import`, import `group_user` using the group's and user's `id` separated by a colon (`:`). For example:
 ```shell
-terraform import group_user.example "group_id:user_id"
+% terraform import group_user.example groupida-bbbb-cccc-dddd-eeeeeeeeeeee:userida-bbbb-cccc-dddd-eeeeeeeeeeee
 ```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -42,8 +42,15 @@ resource "tableau_project" "test" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_project` using the `id` attribute. For example:
+```terraform
+import {
+  to = tableau_project.example
+  id = "projaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+}
+```
 
+Using `terraform import`, import `tableau_project` using the `id` attribute. For example:
 ```shell
-terraform import tableau_project.example "project_id"
+% terraform import tableau_project.example projaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
 ```

--- a/docs/resources/project_permission.md
+++ b/docs/resources/project_permission.md
@@ -41,8 +41,15 @@ resource "tableau_project_permission" "test_permission" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_project_permission` using the `projects`, project's id, `permissions`, entity type (`users` or `groups`), entity's id, capability name and capability mode (`Allow` or `Deny`) separated by slash (`/`). For example:
+```terraform
+import {
+  to = tableau_project_permission.example
+  id = "projects/projaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Write/Allow"
+}
+```
 
+Using `terraform import`, import `tableau_project_permission` using the `projects`, project's id, `permissions`, entity type (`users` or `groups`), entity's id, capability name and capability mode (`Allow` or `Deny`) separated by slash (`/`). For example:
 ```shell
-terraform import tableau_project_permission.example "projects/<project_id>/permissions/<entity_type>/<entity_id>/<capability_name>/<capability_mode>"
+% terraform import tableau_project_permission.example projects/projaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Write/Allow
 ```

--- a/docs/resources/site.md
+++ b/docs/resources/site.md
@@ -37,8 +37,15 @@ resource "tableau_site" "test" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_site` using the `id` attribute. For example:
+```terraform
+import {
+  to = tableau_site.example
+  id = "abc"
+}
+```
 
+Using `terraform import`, import `tableau_site` using the `id` attribute. For example:
 ```shell
-terraform import tableau_site.example "site_id"
+% terraform import tableau_site.example abc
 ```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -40,8 +40,17 @@ resource "tableau_user" "example" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_user` using the `id` attribute. For example:
+
+```terraform
+import {
+  to = tableau_user.example
+  id = "usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+}
+```
+
+Using `terraform import`, import `tableau_user` using the `id` attribute. For example:
 
 ```shell
-terraform import tableau_user.example "user_id"
+% terraform import tableau_user.example usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee
 ```

--- a/docs/resources/view_permission.md
+++ b/docs/resources/view_permission.md
@@ -41,8 +41,15 @@ resource "tableau_view_permission" "test_permission" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_view_permission` using the `views`, view's id, `permissions`, entity type (`users` or `groups`), entity's id,  capability name and capability mode (`Allow` or `Deny`) separated by slash (`/`). For example:
+```terraform
+import {
+  to = tableau_view_permission.example
+  id = "views/viewaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Write/Allow"
+}
+```
 
+Using `terraform import`, import `tableau_view_permission` using the `views`, view's id, `permissions`, entity type (`users` or `groups`), entity's id,  capability name and capability mode (`Allow` or `Deny`) separated by slash (`/`). For example:
 ```shell
-terraform import tableau_view_permission.example "views/<view_id>/permissions/<entity_type>/<entity_id>/<capability_name>/<capability_mode>"
+% terraform import tableau_view_permission.example views/viewaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Write/Allow
 ```

--- a/docs/resources/virtual_connection_permission.md
+++ b/docs/resources/virtual_connection_permission.md
@@ -41,8 +41,15 @@ resource "tableau_virtual_connection_permission" "test_permission" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_virtual_connection_permission` using the `virtualconnections`, virtualconnection's id, `permissions`,  entity type (`users` or `groups`), entity's id, capability name and capability mode (`Allow` or `Deny`) separated by slash (`/`). For example:
+```terraform
+import {
+  to = tableau_virtual_connection_permission.example
+  id = "virtualconnections/vconnaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Write/Deny"
+}
+```
 
+Using `terraform import`, import `tableau_virtual_connection_permission` using the `virtualconnections`, virtualconnection's id, `permissions`,  entity type (`users` or `groups`), entity's id, capability name and capability mode (`Allow` or `Deny`) separated by slash (`/`). For example:
 ```shell
-terraform import tableau_virtual_connection_permission.example "virtualconnections/<virtualconnection_id>/permissions/<entity_type>/<entity_id>/<capability_name>/<capability_mode>"
+% terraform import tableau_virtual_connection_permission.example virtualconnections/vconnaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Write/Deny
 ```

--- a/docs/resources/workbook_permission.md
+++ b/docs/resources/workbook_permission.md
@@ -41,8 +41,15 @@ resource "tableau_workbook_permission" "test_permission" {
 
 ## Import
 
-Import is supported using the following syntax:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `tableau_workbook_permission` using the `workbooks`, workbook's id, `permissions`, entity type (`users` or `groups`), entity's id, capability name and capability mode (`Allow` or `Deny`) separated by slash (`/`). For example:
+```terraform
+import {
+  to = tableau_workbook_permission.example
+  id = "workbooks/wbookaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Write/Allow"
+}
+```
 
+Using `terraform import`, import `tableau_workbook_permission` using the `workbooks`, workbook's id, `permissions`, entity type (`users` or `groups`), entity's id, capability name and capability mode (`Allow` or `Deny`) separated by slash (`/`). For example:
 ```shell
-terraform import tableau_workbook_permission.example "workbooks/<workbook_id>/permissions/<entity_type>/<entity_id>/<capability_name>/<capability_mode>"
+% terraform import tableau_workbook_permission.example workbooks/wbookaaa-bbbb-cccc-dddd-eeeeeeeeeeee/permissions/users/usersaaa-bbbb-cccc-dddd-eeeeeeeeeeee/Write/Allow
 ```


### PR DESCRIPTION
Took the idea of having `import {}` blocks with examples from terraform-provider-aws. Of course, one big difference is that tableau seems to have UUID everywhere as `id`, while AWS has i-..., sg-..., etc. as identifiers.