### PR TITLE
chore: all user fields can updated

### DIFF
--- a/tableau/user.go
+++ b/tableau/user.go
@@ -137,10 +137,12 @@ func (c *Client) CreateUser(email, name, fullName, siteRole, authSetting string)
 	return &userResponse.User, nil
 }
 
-func (c *Client) UpdateUser(userID, name, siteRole, authSetting string) (*User, error) {
+func (c *Client) UpdateUser(userID, email, name, fullName, siteRole, authSetting string) (*User, error) {
 
 	newUser := User{
+		Email:       email,
 		Name:        name,
+		FullName:    fullName,
 		SiteRole:    siteRole,
 		AuthSetting: authSetting,
 	}

--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -124,7 +124,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 		)
 		return
 	}
-	_, err = r.client.UpdateUser(createdUser.ID, user.Name, user.SiteRole, user.AuthSetting)
+	_, err = r.client.UpdateUser(createdUser.ID, user.Email, user.Name, user.FullName, user.SiteRole, user.AuthSetting)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating user during create",
@@ -182,11 +182,12 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	user := User{
 		Email:       string(plan.Email.ValueString()),
 		Name:        string(plan.Name.ValueString()),
+		FullName:    string(plan.FullName.ValueString()),
 		SiteRole:    string(plan.SiteRole.ValueString()),
 		AuthSetting: string(plan.AuthSetting.ValueString()),
 	}
 
-	_, err := r.client.UpdateUser(plan.ID.ValueString(), user.Name, user.SiteRole, user.AuthSetting)
+	_, err := r.client.UpdateUser(plan.ID.ValueString(), user.Email, user.Name, user.FullName, user.SiteRole, user.AuthSetting)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Tableau User",
@@ -204,7 +205,9 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	plan.Email = types.StringValue(updatedUser.Email)
 	plan.Name = types.StringValue(updatedUser.Name)
+	plan.FullName = types.StringValue(updatedUser.FullName)
 	plan.SiteRole = types.StringValue(updatedUser.SiteRole)
 	plan.AuthSetting = types.StringValue(updatedUser.AuthSetting)
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))

--- a/tableau/user_resource_test.go
+++ b/tableau/user_resource_test.go
@@ -14,8 +14,8 @@ func TestAccUserResource(t *testing.T) {
 			{
 				Config: providerConfig + `
 resource "tableau_user" "test" {
-  name = "test@test.test"
-  full_name = "test@test.test"
+  name = "name"
+  full_name = "full_name"
   email = "test@test.test"
   site_role = "Viewer"
   auth_setting = "SAML"
@@ -29,8 +29,8 @@ resource "tableau_user" "test" {
 					resource.TestCheckResourceAttrSet("tableau_user.test", "email"),
 					resource.TestCheckResourceAttrSet("tableau_user.test", "site_role"),
 					resource.TestCheckResourceAttrSet("tableau_user.test", "auth_setting"),
-					resource.TestCheckResourceAttr("tableau_user.test", "name", "test@test.test"),
-					resource.TestCheckResourceAttr("tableau_user.test", "full_name", "test@test.test"),
+					resource.TestCheckResourceAttr("tableau_user.test", "name", "name"),
+					resource.TestCheckResourceAttr("tableau_user.test", "full_name", "full_name"),
 					resource.TestCheckResourceAttr("tableau_user.test", "email", "test@test.test"),
 					resource.TestCheckResourceAttr("tableau_user.test", "site_role", "Viewer"),
 					resource.TestCheckResourceAttr("tableau_user.test", "auth_setting", "SAML"),
@@ -47,9 +47,9 @@ resource "tableau_user" "test" {
 			{
 				Config: providerConfig + `
 			resource "tableau_user" "test" {
-              name = "test@test.test"
-              full_name = "test@test.test"
-              email = "test@test.test"
+              name = "name_update"
+              full_name = "full_name_update"
+              email = "test_update@test.test"
               site_role = "Viewer"
               auth_setting = "ServerDefault"
             }
@@ -62,9 +62,9 @@ resource "tableau_user" "test" {
 					resource.TestCheckResourceAttrSet("tableau_user.test", "email"),
 					resource.TestCheckResourceAttrSet("tableau_user.test", "site_role"),
 					resource.TestCheckResourceAttrSet("tableau_user.test", "auth_setting"),
-					resource.TestCheckResourceAttr("tableau_user.test", "name", "test@test.test"),
-					resource.TestCheckResourceAttr("tableau_user.test", "full_name", "test@test.test"),
-					resource.TestCheckResourceAttr("tableau_user.test", "email", "test@test.test"),
+					resource.TestCheckResourceAttr("tableau_user.test", "name", "name_update"),
+					resource.TestCheckResourceAttr("tableau_user.test", "full_name", "full_name_update"),
+					resource.TestCheckResourceAttr("tableau_user.test", "email", "test_update@test.test"),
 					resource.TestCheckResourceAttr("tableau_user.test", "site_role", "Viewer"),
 					resource.TestCheckResourceAttr("tableau_user.test", "auth_setting", "ServerDefault"),
 				),


### PR DESCRIPTION
I think we should allow updating all user fields because there's only one case where it could lead to an error - [Active Directory](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#update_user). If you use Active Directory + Terraform you have to know "consequences"