### PR TITLE
Adds tableau_workbook resource

### DIFF
--- a/examples/resources/tableau_workbook/import.sh
+++ b/examples/resources/tableau_workbook/import.sh
@@ -1,0 +1,1 @@
+terraform import tableau_workbook.example "workbook_uuid"

--- a/examples/resources/tableau_workbook/resource.tf
+++ b/examples/resources/tableau_workbook/resource.tf
@@ -1,0 +1,29 @@
+data "tableau_users" "users" {}
+data "tableau_projects" "projects" {}
+
+resource tableau_workbook "example" {
+  name               = "example"
+  description        = "example about workbook resource"
+  encrypt_extracts   = "true"
+  thumbnails_user_id = data.tableau_users.users[0].id
+  project_id         = data.tableau_projects.projects[0].id
+  show_tabs          = "false"
+  workbook_filename  = "wbfile.twb"
+  workbook_content   = file("wbfile.twb")
+}
+
+/*
+Example of minimalistic workbook content of wbfile.twb:
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- build 20251.25.0219.1921                               -->
+<workbook original-version='18.1' source-build='2024.3.0 (20243.25.0110.1701)' version='18.1' xml:base='https://SITE_NAME.tableau.com' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <document-format-change-manifest />
+  <preferences />
+  <datasources />
+  <worksheets>
+    <worksheet name='Sheet 1' />
+  </worksheets>
+  <windows />
+</workbook>
+*/

--- a/tableau/client.go
+++ b/tableau/client.go
@@ -43,6 +43,10 @@ type SignInResponse struct {
 	SignInResponseData SignInResponseData `json:"credentials"`
 }
 
+type requestOptions struct {
+	contentType string
+}
+
 func NewClient(server, username, password, personalAccessTokenName, personalAccessTokenSecret, site, serverVersion *string) (*Client, error) {
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 10 * time.Second},
@@ -93,9 +97,15 @@ func NewClient(server, username, password, personalAccessTokenName, personalAcce
 	return &c, nil
 }
 
-func (c *Client) doRequest(req *http.Request) ([]byte, error) {
+func (c *Client) doRequest(req *http.Request, optFns ...func(*requestOptions)) ([]byte, error) {
+	reqOpts := &requestOptions{
+		contentType: "application/json",
+	}
+	for _, optFn := range optFns {
+		optFn(reqOpts)
+	}
 	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", reqOpts.contentType)
 	req.Header.Add("X-Tableau-Auth", c.AuthToken)
 
 	res, err := c.HTTPClient.Do(req)

--- a/tableau/provider.go
+++ b/tableau/provider.go
@@ -261,7 +261,7 @@ func (p *tableauProvider) DataSources(_ context.Context) []func() datasource.Dat
 		VirtualConnectionConnectionsDataSource,
 		VirtualConnectionRevisionsDataSource,
 		WorkbookConnectionsDataSource,
-    WorkbooksDataSource,
+		WorkbooksDataSource,
 		WorkbookRevisionsDataSource,
 	}
 }
@@ -277,6 +277,7 @@ func (p *tableauProvider) Resources(_ context.Context) []func() resource.Resourc
 		NewProjectPermissionResource,
 		NewViewPermissionResource,
 		NewVirtualConnectionPermissionResource,
+		NewWorkbookResource,
 		NewWorkbookPermissionResource,
 	}
 }

--- a/tableau/workbook.go
+++ b/tableau/workbook.go
@@ -1,36 +1,71 @@
 package tableau
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
+	"strings"
 )
+
+type WorkbookOwner struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type WorkbookProject struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type XMLWorkbookOwner struct {
+	XMLName xml.Name `xml:"owner"`
+	ID      string   `xml:"id,attr"`
+}
+
+type XMLWorkbookProject struct {
+	XMLName xml.Name `xml:"project"`
+	ID      string   `xml:"id,attr"`
+}
+
+type XMLWorkbook struct {
+	XMLName          xml.Name           `xml:"workbook"`
+	Name             string             `xml:"name,attr"`
+	Description      string             `xml:"description,attr"`
+	Project          XMLWorkbookProject `xml:"project"`
+	ShowTabs         string             `xml:"showTabs,attr"`
+	ThumbnailsUserID string             `xml:"thumbnailsUserId,attr"`
+	EncryptExtracts  string             `xml:"encryptExtracts,attr"`
+	Owner            XMLWorkbookOwner   `xml:"owner"`
+}
+
+type XMLTsRequest struct {
+	XMLName  xml.Name    `xml:"tsRequest"`
+	Workbook XMLWorkbook `xml:"workbook"`
+}
 
 type Workbook struct {
 	ID              string `json:"id,omitempty"`
 	Name            string `json:"name,omitempty"`
 	Description     string `json:"description,omitempty"`
-	DefaultViewID   string `json:"defaultViewId,omitempty"`
 	EncryptExtracts string `json:"encryptExtracts,omitempty"`
 	ShowTabs        string `json:"showTabs,omitempty"`
 	Size            string `json:"size,omitempty"` // size in megabytes
 	ContentURL      string `json:"contentUrl,omitempty"`
 	WebPageURL      string `json:"webpageUrl,omitempty"`
 	Location        struct {
-		ID string `json:"id,omitempty"`
-		// Type string `json:"type,omitempty"` // for example "Project"
-		// Name string `json:"name,omitempty"`
+		ID   string `json:"id,omitempty"`
+		Type string `json:"type,omitempty"`
+		Name string `json:"name,omitempty"`
 	} `json:"location,omitempty"`
-	Owner struct {
-		ID string `json:"id,omitempty"`
-		// Name string `json:"name,omitempty"`
-	} `json:"owner,omitempty"`
-	Project struct {
-		ID string `json:"id,omitempty"`
-		// Name string `json:"name,omitempty"`
-	} `json:"project,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
+	Project   WorkbookProject `json:"project,omitempty"`
+	Owner     WorkbookOwner   `json:"owner,omitempty"`
+	CreatedAt string          `json:"createdAt,omitempty"`
+	UpdatedAt string          `json:"updatedAt,omitempty"`
 	// Tags
 }
 
@@ -40,6 +75,10 @@ type WorkbookRequest struct {
 
 type WorkbooksResponse struct {
 	Workbooks []Workbook `json:"workbook"`
+}
+
+type WorkbookResponse struct {
+	Workbook Workbook `json:"workbook"`
 }
 
 type WorkbookListResponse struct {
@@ -90,4 +129,164 @@ func (c *Client) GetWorkbooks() ([]Workbook, error) {
 	}
 
 	return allWorkbooks, nil
+}
+
+func (c *Client) GetWorkbook(id string) (*Workbook, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/workbooks", c.ApiUrl), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	workbookListResponse := WorkbookListResponse{}
+	err = json.Unmarshal(body, &workbookListResponse)
+	if err != nil {
+		return nil, err
+	}
+	pageNumber, totalPageCount, totalAvailable, err := GetPaginationNumbers(workbookListResponse.Pagination)
+	if err != nil {
+		return nil, err
+	}
+	allWorkbooks := make([]Workbook, 0, totalAvailable)
+	allWorkbooks = append(allWorkbooks, workbookListResponse.WorkbooksResponse.Workbooks...)
+	for idx := range allWorkbooks {
+		if allWorkbooks[idx].ID == id {
+			return &allWorkbooks[idx], nil
+		}
+	}
+	for page := pageNumber + 1; page <= totalPageCount; page++ {
+		fmt.Printf("Searching page %d", page)
+		req, err = http.NewRequest("GET", fmt.Sprintf("%s/workbooks?pageNumber=%d", c.ApiUrl, page), nil)
+		if err != nil {
+			return nil, err
+		}
+		body, err = c.doRequest(req)
+		if err != nil {
+			return nil, err
+		}
+		workbookListResponse = WorkbookListResponse{}
+		err = json.Unmarshal(body, &workbookListResponse)
+		if err != nil {
+			return nil, err
+		}
+		allWorkbooks = append(allWorkbooks, workbookListResponse.WorkbooksResponse.Workbooks...)
+		for idx := range allWorkbooks {
+			if allWorkbooks[idx].ID == id {
+				return &allWorkbooks[idx], nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("failed to find workbook with ID %s", id)
+}
+
+func (c *Client) CreateWorkbook(ctx context.Context, name, projectID, showTabs, thumbnailsUserID, wbFilename string, wbContent []byte) (string, error) {
+
+	workbookRequest := XMLTsRequest{
+		Workbook: XMLWorkbook{
+			Name:             name,
+			Project:          XMLWorkbookProject{ID: projectID},
+			ShowTabs:         showTabs,
+			ThumbnailsUserID: thumbnailsUserID,
+		},
+	}
+	newWorkbookXml, err := xml.Marshal(workbookRequest)
+	if err != nil {
+		return "", err
+	}
+	reqBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(reqBody)
+	part, err := writer.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": {"name=\"request_payload\""},
+		"Content-Type":        {"application/xml"},
+	})
+	if err != nil {
+		return "", err
+	}
+	if _, err = part.Write(newWorkbookXml); err != nil {
+		return "", err
+	}
+	part, err = writer.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": {fmt.Sprintf("name=\"tableau_workbook\"; filename=\"%s\"", wbFilename)},
+		"Content-Type":        {"application/octet-stream"},
+	})
+	if err != nil {
+		return "", err
+	}
+	if _, err = part.Write(wbContent); err != nil {
+		return "", err
+	}
+	if err = writer.Close(); err != nil {
+		return "", err
+	}
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/workbooks", c.ApiUrl), reqBody)
+	if err != nil {
+		return "", err
+	}
+	respBody, err := c.doRequest(req, func(o *requestOptions) {
+		o.contentType = "multipart/mixed; boundary=" + writer.Boundary()
+	})
+	if err != nil {
+		return "", err
+	}
+	workbookResponse := WorkbookResponse{}
+	if err = json.Unmarshal(respBody, &workbookResponse); err != nil {
+		return "", err
+	}
+	return workbookResponse.Workbook.ID, nil
+}
+
+func (c *Client) UpdateWorkbook(id, name, projectID, showTabs, description, encryptExtracts, ownerID string) (*Workbook, error) {
+
+	workbookRequest := WorkbookRequest{
+		Workbook: Workbook{
+			ID:              id,
+			Name:            name,
+			Project:         WorkbookProject{ID: projectID},
+			ShowTabs:        showTabs,
+			Description:     description,
+			EncryptExtracts: encryptExtracts,
+			Owner:           WorkbookOwner{ID: ownerID},
+		},
+	}
+
+	newWorkbookJson, err := json.Marshal(workbookRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/workbooks/%s", c.ApiUrl, id), strings.NewReader(string(newWorkbookJson)))
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	workbookResponse := WorkbookResponse{}
+	err = json.Unmarshal(body, &workbookResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workbookResponse.Workbook, nil
+}
+
+func (c *Client) DeleteWorkbook(id string) error {
+
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/workbooks/%s", c.ApiUrl, id), nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/tableau/workbook_resource.go
+++ b/tableau/workbook_resource.go
@@ -1,0 +1,224 @@
+package tableau
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                = &workbookResource{}
+	_ resource.ResourceWithConfigure   = &workbookResource{}
+	_ resource.ResourceWithImportState = &workbookResource{}
+)
+
+func NewWorkbookResource() resource.Resource {
+	return &workbookResource{}
+}
+
+type workbookResource struct {
+	client *Client
+}
+
+type workbookResourceModel struct {
+	ID               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	ProjectID        types.String `tfsdk:"project_id"`
+	ShowTabs         types.String `tfsdk:"show_tabs"`
+	ThumbnailsUserID types.String `tfsdk:"thumbnails_user_id"`
+	WorkbookFilename types.String `tfsdk:"workbook_filename"`
+	WorkbookContent  types.String `tfsdk:"workbook_content"`
+	Description      types.String `tfsdk:"description"`
+	EncryptExtracts  types.String `tfsdk:"encrypt_extracts"`
+	OwnerID          types.String `tfsdk:"owner_id"`
+}
+
+func (r *workbookResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_workbook"
+}
+
+func (r *workbookResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{ // Update
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{ // Create && Update
+				Required:    true,
+				Description: "Workbook name",
+			},
+			"description": schema.StringAttribute{
+				Optional:    true,
+				Description: "Description for the workbook",
+			},
+			"encrypt_extracts": schema.StringAttribute{
+				Optional:    true,
+				Description: "Whether or not extracts are encrypted",
+				Validators: []validator.String{
+					stringvalidator.OneOf([]string{
+						"true",
+						"false",
+					}...),
+				},
+			},
+			"owner_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the workbook owner",
+			},
+			"project_id": schema.StringAttribute{ // Create && Update
+				Required:    true,
+				Description: "Workbook belongs to project with ID",
+			},
+			"show_tabs": schema.StringAttribute{ // Create && Update
+				Required:    true,
+				Description: "Whether or not show views in tabs",
+				Validators: []validator.String{
+					stringvalidator.OneOf([]string{
+						"true",
+						"false",
+					}...),
+				},
+			},
+			"thumbnails_user_id": schema.StringAttribute{ // ONLY Create
+				Required:    true,
+				Description: "Specify user for thumbnail (used when creating workbook)",
+			},
+			"workbook_filename": schema.StringAttribute{ // ONLY Create
+				Required:    true,
+				Description: "Filename of workbook file (used when creating workbook)",
+			},
+			"workbook_content": schema.StringAttribute{ // ONLY Create
+				Required:    true,
+				Description: "Content of workbook file (used when creating workbook)",
+			},
+		},
+	}
+}
+
+func (r *workbookResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan workbookResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	name := string(plan.Name.ValueString())
+	projectID := string(plan.ProjectID.ValueString())
+	showTabs := string(plan.ShowTabs.ValueString())
+	thumbnailsUserID := string(plan.ThumbnailsUserID.ValueString())
+	wbContent := string(plan.WorkbookContent.ValueString())
+	wbFilename := string(plan.WorkbookFilename.ValueString())
+	id, err := r.client.CreateWorkbook(ctx, name, projectID, showTabs, thumbnailsUserID, wbFilename, []byte(wbContent))
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating workbook",
+			"Could not create workbook, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(id)
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *workbookResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state workbookResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	workbook, err := r.client.GetWorkbook(state.ID.ValueString())
+	if err != nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.Name = types.StringValue(workbook.Name)
+	state.ProjectID = types.StringValue(workbook.Project.ID)
+	state.ShowTabs = types.StringValue(workbook.ShowTabs)
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *workbookResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan workbookResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	wb := Workbook{
+		ID:              plan.ID.ValueString(),
+		Name:            plan.Name.ValueString(),
+		Project:         WorkbookProject{ID: plan.ProjectID.ValueString()},
+		ShowTabs:        plan.ShowTabs.ValueString(),
+		Description:     plan.Description.ValueString(),
+		EncryptExtracts: plan.EncryptExtracts.ValueString(),
+		Owner:           WorkbookOwner{ID: plan.OwnerID.ValueString()},
+	}
+	_, err := r.client.UpdateWorkbook(
+		wb.ID, wb.Name, wb.Project.ID, wb.ShowTabs, wb.Description, wb.EncryptExtracts, wb.Owner.ID,
+	)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating Tableau Workbook",
+			"Could not update workbook, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *workbookResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state workbookResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteWorkbook(state.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting Tableau Workbook",
+			"Could not delete workbook, unexpected error: "+err.Error(),
+		)
+	}
+}
+
+func (r *workbookResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.client = req.ProviderData.(*Client)
+}
+
+func (r *workbookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tableau/workbooks_data_source.go
+++ b/tableau/workbooks_data_source.go
@@ -28,10 +28,13 @@ type workbooksNestedDataModel struct {
 	EncryptExtracts types.String `tfsdk:"encrypt_extracts"`
 	ShowTabs        types.String `tfsdk:"show_tabs"`
 	Size            types.String `tfsdk:"size"`
-	DefaultViewID   types.String `tfsdk:"default_view_id"`
 	LocationID      types.String `tfsdk:"location_id"`
+	LocationType    types.String `tfsdk:"location_type"`
+	LocationName    types.String `tfsdk:"location_name"`
 	OwnerID         types.String `tfsdk:"owner_id"`
+	OwnerName       types.String `tfsdk:"owner_name"`
 	ProjectID       types.String `tfsdk:"project_id"`
+	ProjectName     types.String `tfsdk:"project_name"`
 	ContentURL      types.String `tfsdk:"content_url"`
 	WebPageURL      types.String `tfsdk:"web_page_url"`
 	CreatedAt       types.String `tfsdk:"created_at"`
@@ -80,27 +83,39 @@ func (d *workbooksDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						},
 						"show_tabs": schema.StringAttribute{
 							Computed:    true,
-							Description: "Whether or not this workbook show tabs",
+							Description: "Whether or not show views in tabs",
 						},
 						"size": schema.StringAttribute{
 							Computed:    true,
 							Description: "Workbook size in mega bytes",
 						},
-						"default_view_id": schema.StringAttribute{
-							Computed:    true,
-							Description: "ID of the workbook default view",
-						},
 						"location_id": schema.StringAttribute{
 							Computed:    true,
 							Description: "ID of the workbook location",
 						},
-						"project_id": schema.StringAttribute{
+						"location_name": schema.StringAttribute{
 							Computed:    true,
-							Description: "ID of the workbook project",
+							Description: "Name of the workbook location",
+						},
+						"location_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "Type of the workbook location",
 						},
 						"owner_id": schema.StringAttribute{
 							Computed:    true,
 							Description: "ID of the workbook owner",
+						},
+						"owner_name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Name of the workbook owner",
+						},
+						"project_id": schema.StringAttribute{
+							Computed:    true,
+							Description: "ID of the project",
+						},
+						"project_name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Name of the project",
 						},
 						"created_at": schema.StringAttribute{
 							Computed:    true,
@@ -147,14 +162,17 @@ func (d *workbooksDataSource) Read(ctx context.Context, req datasource.ReadReque
 			EncryptExtracts: types.StringValue(workbook.EncryptExtracts),
 			ShowTabs:        types.StringValue(workbook.ShowTabs),
 			Size:            types.StringValue(workbook.Size),
-			DefaultViewID:   types.StringValue(workbook.DefaultViewID),
-			LocationID:      types.StringValue(workbook.Location.ID),
 			OwnerID:         types.StringValue(workbook.Owner.ID),
+			OwnerName:       types.StringValue(workbook.Owner.Name),
 			ProjectID:       types.StringValue(workbook.Project.ID),
+			ProjectName:     types.StringValue(workbook.Project.Name),
 			CreatedAt:       types.StringValue(workbook.CreatedAt),
 			UpdatedAt:       types.StringValue(workbook.UpdatedAt),
 			ContentURL:      types.StringValue(workbook.ContentURL),
 			WebPageURL:      types.StringValue(workbook.WebPageURL),
+			LocationID:      types.StringValue(workbook.Location.ID),
+			LocationType:    types.StringValue(workbook.Location.Type),
+			LocationName:    types.StringValue(workbook.Location.Name),
 		}
 		state.Workbooks = append(state.Workbooks, workbooksDataModel)
 	}


### PR DESCRIPTION
tableau_workbook creation is picky about content-types, so I created data structures for XML AND JSON. It also required that doRequest needs to support override for Content-Type.  Workbooks creation also need tableau workbook file (`*.twb`), so we added one into `examples/`.

DefaultViewId was dropped from tableau_workbook data source, because when you create new workbook, it will automatically get default view id (you might be able to define it, but ...), which leads to errors if terraform feels that we were not supposed to change DefaultViewId, but suddenly it has a value.
Added location name and type, project and owner names as read-only values. I would preferred to have them as map (for example location.id, location.name, location.type instead of location_id, location_name and location_type), but haven't yet figured out how the schema would need to be defined.

One unchartered option is whether or not, we could create tableau_workbook resource with HTTP request, which main content-type would be `multipart/mixed` with JSON and twb file instead of XML and twb file. But this current implementation is capable to create, update and destroy workbook resources in tableau.