### PR TITLE
log.Fatal(err) if terraform returns error

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log"
 
 	"github.com/gthesheep/terraform-provider-tableau/tableau"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -11,7 +12,10 @@ import (
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name tableau
 
 func main() {
-	providerserver.Serve(context.Background(), tableau.New, providerserver.ServeOpts{
+	err := providerserver.Serve(context.Background(), tableau.New, providerserver.ServeOpts{
 		Address: "registry.terraform.io/gthesheep/tableau",
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Since `providerserver.Serve()` returns `error`, `gosec` for example complains that we are not checking it. There are couple easy ways to deal with it. One is that we simply ignore it with `_ = providerserver.Serve(...)`, but at least I would prefer to log it as a fatal error unless I know that it is fine to get some specific error messages once in a while.