### PR TITLE
StringValue() from types.String already returns string

### DIFF
--- a/tableau/datasource_permission_resource.go
+++ b/tableau/datasource_permission_resource.go
@@ -115,10 +115,10 @@ func (r *datasourcePermissionResource) Create(ctx context.Context, req resource.
 		return
 	}
 
-	datasourceID := string(plan.DatasourceID.ValueString())
+	datasourceID := plan.DatasourceID.ValueString()
 	capability := Capability{
-		Name: string(plan.CapabilityName.ValueString()),
-		Mode: string(plan.CapabilityMode.ValueString()),
+		Name: plan.CapabilityName.ValueString(),
+		Mode: plan.CapabilityMode.ValueString(),
 	}
 	capabilities := Capabilities{
 		Capabilities: []Capability{capability},
@@ -128,11 +128,11 @@ func (r *datasourcePermissionResource) Create(ctx context.Context, req resource.
 	}
 
 	entityType := "users"
-	entityID := string(plan.UserID.ValueString())
-	if plan.UserID.ValueString() != "" {
+	entityID := plan.UserID.ValueString()
+	if entityID != "" {
 		granteeCapability.User = &User{ID: entityID}
 	} else {
-		entityID = string(plan.GroupID.ValueString())
+		entityID = plan.GroupID.ValueString()
 		entityType = "groups"
 		granteeCapability.Group = &Group{ID: entityID}
 	}

--- a/tableau/group_resource.go
+++ b/tableau/group_resource.go
@@ -86,10 +86,10 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	group := Group{
-		Name: string(plan.Name.ValueString()),
+		Name: plan.Name.ValueString(),
 	}
 	if plan.MinimumSiteRole.ValueString() != "" {
-		group.MinimumSiteRole = string(plan.MinimumSiteRole.ValueString())
+		group.MinimumSiteRole = plan.MinimumSiteRole.ValueString()
 	}
 
 	createdGroup, err := r.client.CreateGroup(group.Name, group.MinimumSiteRole)
@@ -149,8 +149,8 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	group := Group{
-		Name:            string(plan.Name.ValueString()),
-		MinimumSiteRole: string(plan.MinimumSiteRole.ValueString()),
+		Name:            plan.Name.ValueString(),
+		MinimumSiteRole: plan.MinimumSiteRole.ValueString(),
 	}
 
 	_, err := r.client.UpdateGroup(plan.ID.ValueString(), group.Name, group.MinimumSiteRole)

--- a/tableau/group_user_resource.go
+++ b/tableau/group_user_resource.go
@@ -70,7 +70,7 @@ func (r *groupUserResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	groupUser := User{
-		ID: string(plan.UserID.ValueString()),
+		ID: plan.UserID.ValueString(),
 	}
 
 	_, err := r.client.CreateGroupUser(plan.GroupID.ValueString(), groupUser.ID)

--- a/tableau/project_permission_resource.go
+++ b/tableau/project_permission_resource.go
@@ -111,10 +111,10 @@ func (r *projectPermissionResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	projectID := string(plan.ProjectID.ValueString())
+	projectID := plan.ProjectID.ValueString()
 	capability := Capability{
-		Name: string(plan.CapabilityName.ValueString()),
-		Mode: string(plan.CapabilityMode.ValueString()),
+		Name: plan.CapabilityName.ValueString(),
+		Mode: plan.CapabilityMode.ValueString(),
 	}
 	capabilities := Capabilities{
 		Capabilities: []Capability{capability},
@@ -124,11 +124,11 @@ func (r *projectPermissionResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	entityType := "users"
-	entityID := string(plan.UserID.ValueString())
+	entityID := plan.UserID.ValueString()
 	if plan.UserID.ValueString() != "" {
 		granteeCapability.User = &User{ID: entityID}
 	} else {
-		entityID = string(plan.GroupID.ValueString())
+		entityID = plan.GroupID.ValueString()
 		entityType = "groups"
 		granteeCapability.Group = &Group{ID: entityID}
 	}

--- a/tableau/project_resource.go
+++ b/tableau/project_resource.go
@@ -105,15 +105,11 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	project := Project{
-		Name:               string(plan.Name.ValueString()),
-		Description:        string(plan.Description.ValueString()),
-		ContentPermissions: string(plan.ContentPermissions.ValueString()),
-	}
-	if plan.ParentProjectID.ValueString() != "" {
-		project.ParentProjectID = string(plan.ParentProjectID.ValueString())
-	}
-	if plan.OwnerID.ValueString() != "" {
-		project.Owner.ID = string(plan.OwnerID.ValueString())
+		Name:               plan.Name.ValueString(),
+		Description:        plan.Description.ValueString(),
+		ContentPermissions: plan.ContentPermissions.ValueString(),
+		ParentProjectID:    plan.ParentProjectID.ValueString(),
+		Owner:              Owner{ID: plan.OwnerID.ValueString()},
 	}
 
 	createdProject, err := r.client.CreateProject(project.Name, project.ParentProjectID, project.Description, project.ContentPermissions, project.Owner.ID)
@@ -175,17 +171,12 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	project := Project{
-		Name:               string(plan.Name.ValueString()),
-		Description:        string(plan.Description.ValueString()),
-		ContentPermissions: string(plan.ContentPermissions.ValueString()),
+		Name:               plan.Name.ValueString(),
+		Description:        plan.Description.ValueString(),
+		ContentPermissions: plan.ContentPermissions.ValueString(),
+		ParentProjectID:    plan.ParentProjectID.ValueString(),
+		Owner:              Owner{ID: plan.OwnerID.ValueString()},
 	}
-	if plan.ParentProjectID.ValueString() != "" {
-		project.ParentProjectID = string(plan.ParentProjectID.ValueString())
-	}
-	if plan.OwnerID.ValueString() != "" {
-		project.Owner.ID = string(plan.OwnerID.ValueString())
-	}
-
 	_, err := r.client.UpdateProject(plan.ID.ValueString(), project.Name, project.ParentProjectID, project.Description, project.ContentPermissions, project.Owner.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/tableau/site_resource.go
+++ b/tableau/site_resource.go
@@ -70,8 +70,8 @@ func (r *siteResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	site := Site{
-		Name:       string(plan.Name.ValueString()),
-		ContentURL: string(plan.ContentURL.ValueString()),
+		Name:       plan.Name.ValueString(),
+		ContentURL: plan.ContentURL.ValueString(),
 	}
 
 	createdSite, err := r.client.CreateSite(site.Name, site.ContentURL)
@@ -127,8 +127,8 @@ func (r *siteResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	site := Site{
-		Name:       string(plan.Name.ValueString()),
-		ContentURL: string(plan.ContentURL.ValueString()),
+		Name:       plan.Name.ValueString(),
+		ContentURL: plan.ContentURL.ValueString(),
 	}
 
 	_, err := r.client.UpdateSite(plan.ID.ValueString(), site.Name, site.ContentURL)

--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -109,11 +109,11 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	user := User{
-		Email:       string(plan.Email.ValueString()),
-		Name:        string(plan.Name.ValueString()),
-		FullName:    string(plan.FullName.ValueString()),
-		SiteRole:    string(plan.SiteRole.ValueString()),
-		AuthSetting: string(plan.AuthSetting.ValueString()),
+		Email:       plan.Email.ValueString(),
+		Name:        plan.Name.ValueString(),
+		FullName:    plan.FullName.ValueString(),
+		SiteRole:    plan.SiteRole.ValueString(),
+		AuthSetting: plan.AuthSetting.ValueString(),
 	}
 
 	createdUser, err := r.client.CreateUser(user.Email, user.Name, user.FullName, user.SiteRole, user.AuthSetting)
@@ -180,11 +180,11 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	user := User{
-		Email:       string(plan.Email.ValueString()),
-		Name:        string(plan.Name.ValueString()),
-		FullName:    string(plan.FullName.ValueString()),
-		SiteRole:    string(plan.SiteRole.ValueString()),
-		AuthSetting: string(plan.AuthSetting.ValueString()),
+		Email:       plan.Email.ValueString(),
+		Name:        plan.Name.ValueString(),
+		FullName:    plan.FullName.ValueString(),
+		SiteRole:    plan.SiteRole.ValueString(),
+		AuthSetting: plan.AuthSetting.ValueString(),
 	}
 
 	_, err := r.client.UpdateUser(plan.ID.ValueString(), user.Email, user.Name, user.FullName, user.SiteRole, user.AuthSetting)

--- a/tableau/view_permission_resource.go
+++ b/tableau/view_permission_resource.go
@@ -121,10 +121,10 @@ func (r *viewPermissionResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	viewID := string(plan.ViewID.ValueString())
+	viewID := plan.ViewID.ValueString()
 	capability := Capability{
-		Name: string(plan.CapabilityName.ValueString()),
-		Mode: string(plan.CapabilityMode.ValueString()),
+		Name: plan.CapabilityName.ValueString(),
+		Mode: plan.CapabilityMode.ValueString(),
 	}
 	capabilities := Capabilities{
 		Capabilities: []Capability{capability},
@@ -134,11 +134,11 @@ func (r *viewPermissionResource) Create(ctx context.Context, req resource.Create
 	}
 
 	entityType := "users"
-	entityID := string(plan.UserID.ValueString())
-	if plan.UserID.ValueString() != "" {
+	entityID := plan.UserID.ValueString()
+	if entityID != "" {
 		granteeCapability.User = &User{ID: entityID}
 	} else {
-		entityID = string(plan.GroupID.ValueString())
+		entityID = plan.GroupID.ValueString()
 		entityType = "groups"
 		granteeCapability.Group = &Group{ID: entityID}
 	}

--- a/tableau/virtual_connection_permission_resource.go
+++ b/tableau/virtual_connection_permission_resource.go
@@ -114,10 +114,10 @@ func (r *virtualConnectionPermissionResource) Create(ctx context.Context, req re
 		return
 	}
 
-	virtualConnectionID := string(plan.VirtualConnectionID.ValueString())
+	virtualConnectionID := plan.VirtualConnectionID.ValueString()
 	capability := Capability{
-		Name: string(plan.CapabilityName.ValueString()),
-		Mode: string(plan.CapabilityMode.ValueString()),
+		Name: plan.CapabilityName.ValueString(),
+		Mode: plan.CapabilityMode.ValueString(),
 	}
 	capabilities := Capabilities{
 		Capabilities: []Capability{capability},
@@ -127,11 +127,11 @@ func (r *virtualConnectionPermissionResource) Create(ctx context.Context, req re
 	}
 
 	entityType := "users"
-	entityID := string(plan.UserID.ValueString())
+	entityID := plan.UserID.ValueString()
 	if plan.UserID.ValueString() != "" {
 		granteeCapability.User = &User{ID: entityID}
 	} else {
-		entityID = string(plan.GroupID.ValueString())
+		entityID = plan.GroupID.ValueString()
 		entityType = "groups"
 		granteeCapability.Group = &Group{ID: entityID}
 	}

--- a/tableau/workbook_permission_resource.go
+++ b/tableau/workbook_permission_resource.go
@@ -124,10 +124,10 @@ func (r *workbookPermissionResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	workbookID := string(plan.WorkbookID.ValueString())
+	workbookID := plan.WorkbookID.ValueString()
 	capability := Capability{
-		Name: string(plan.CapabilityName.ValueString()),
-		Mode: string(plan.CapabilityMode.ValueString()),
+		Name: plan.CapabilityName.ValueString(),
+		Mode: plan.CapabilityMode.ValueString(),
 	}
 	capabilities := Capabilities{
 		Capabilities: []Capability{capability},
@@ -137,11 +137,11 @@ func (r *workbookPermissionResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	entityType := "users"
-	entityID := string(plan.UserID.ValueString())
-	if plan.UserID.ValueString() != "" {
+	entityID := plan.UserID.ValueString()
+	if entityID != "" {
 		granteeCapability.User = &User{ID: entityID}
 	} else {
-		entityID = string(plan.GroupID.ValueString())
+		entityID = plan.GroupID.ValueString()
 		entityType = "groups"
 		granteeCapability.Group = &Group{ID: entityID}
 	}


### PR DESCRIPTION
Since `ValueString()` for `types.String` already returns `string`, `string(foobar.ValueString())` should always return the same as `foobar.ValueString()`. We can also remove some if statements, since default value of String is empty string (`""`), if we anyway pass the value to function calls.