### PR TITLE
fix crash if resource still in state but not in live environment

### DIFF
--- a/tableau/group_resource.go
+++ b/tableau/group_resource.go
@@ -122,6 +122,7 @@ func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	group, err := r.client.GetGroup(state.ID.ValueString())
 	if err != nil {
 		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	state.ID = types.StringValue(group.ID)

--- a/tableau/group_user_resource.go
+++ b/tableau/group_user_resource.go
@@ -110,6 +110,7 @@ func (r *groupUserResource) Read(ctx context.Context, req resource.ReadRequest, 
 	groupUser, err := r.client.GetGroupUser(groupID, userID)
 	if err != nil {
 		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	combinedID := GetCombinedID(groupID, userID)


### PR DESCRIPTION
Discovered with tableau_group that if terraform state has reference to group that doesn't exist, it will crash the provider due to nil pointer. Based on source code, same problem exists with tableau_group_user resource.
This PR should fix those two resources. Other `*_resource.go` files already had `return` in relevant place.