### PR TITLE
fix project description changes returns error messages

### DIFF
--- a/tableau/project_resource.go
+++ b/tableau/project_resource.go
@@ -88,9 +88,6 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"last_updated": schema.StringAttribute{
 				Computed:    true,
 				Description: "Timestamp of the last Terraform update of the project",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 		},
 	}

--- a/tableau/project_resource.go
+++ b/tableau/project_resource.go
@@ -174,20 +174,11 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		ParentProjectID:    plan.ParentProjectID.ValueString(),
 		Owner:              Owner{ID: plan.OwnerID.ValueString()},
 	}
-	_, err := r.client.UpdateProject(plan.ID.ValueString(), project.Name, project.ParentProjectID, project.Description, project.ContentPermissions, project.Owner.ID)
+	updatedProject, err := r.client.UpdateProject(plan.ID.ValueString(), project.Name, project.ParentProjectID, project.Description, project.ContentPermissions, project.Owner.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Tableau Project",
 			"Could not update project, unexpected error: "+err.Error(),
-		)
-		return
-	}
-
-	updatedProject, err := r.client.GetProject(plan.ID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Tableau Project",
-			"Could not read Tableau project ID "+plan.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}


### PR DESCRIPTION
If project description was changed, it gave me following error message (even though things are properly changed in Tableau):
```
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to module.loyalty.tableau_project.org, provider "provider[\"registry.terraform.io/local/tableau\"]" produced an unexpected new value: .description: was
│ cty.StringVal("org level project"), but now cty.StringVal("org level project and ...").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to module.loyalty.tableau_project.org, provider "provider[\"registry.terraform.io/local/tableau\"]" produced an unexpected new value: .last_updated: was
│ cty.StringVal("Monday, 24-Mar-25 14:53:10 EET"), but now cty.StringVal("Friday, 18-Apr-25 17:43:45 EEST").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

`last_updated` can be fixed by modifying schema. The error about `description` is related to the fact that if we call GetProject right after UpdateProject (at least in my Tableau Cloud) GetProject will return outdated information about project.
I see that there are three possible fixes to it (and chose first one for this PR):
1) use the information that update REST API call gets back from Tableau Cloud
2) use time.Sleep(1) kind of approach to ensure that Tableau has chance to update its internal state
3) issue multiple GetProject calls until we get expected values back from Tableau