### PR TITLE
if resp.Diagnostics.HasError() { return } doesn't provide value at the end of func

### DIFF
--- a/tableau/datasource_data_source.go
+++ b/tableau/datasource_data_source.go
@@ -146,9 +146,6 @@ func (d *datasourceDataSource) Read(ctx context.Context, req datasource.ReadRequ
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *datasourceDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/datasource_permission_resource.go
+++ b/tableau/datasource_permission_resource.go
@@ -153,9 +153,6 @@ func (r *datasourcePermissionResource) Create(ctx context.Context, req resource.
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *datasourcePermissionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -185,9 +182,6 @@ func (r *datasourcePermissionResource) Read(ctx context.Context, req resource.Re
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *datasourcePermissionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -200,9 +194,6 @@ func (r *datasourcePermissionResource) Update(ctx context.Context, req resource.
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *datasourcePermissionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/datasources_data_source.go
+++ b/tableau/datasources_data_source.go
@@ -107,9 +107,6 @@ func (d *datasourcesDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *datasourcesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/default_permissions_data_source.go
+++ b/tableau/default_permissions_data_source.go
@@ -128,9 +128,6 @@ func (d *defaultPermissionsDataSource) Read(ctx context.Context, req datasource.
 	}
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *defaultPermissionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/group_resource.go
+++ b/tableau/group_resource.go
@@ -106,9 +106,6 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -136,9 +133,6 @@ func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -178,9 +172,6 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *groupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/group_user_resource.go
+++ b/tableau/group_user_resource.go
@@ -88,9 +88,6 @@ func (r *groupUserResource) Create(ctx context.Context, req resource.CreateReque
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *groupUserResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -120,9 +117,6 @@ func (r *groupUserResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *groupUserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/tableau/groups_data_source.go
+++ b/tableau/groups_data_source.go
@@ -95,9 +95,6 @@ func (d *groupsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *groupsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/project_data_source.go
+++ b/tableau/project_data_source.go
@@ -83,9 +83,6 @@ func (d *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *projectDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/project_permission_resource.go
+++ b/tableau/project_permission_resource.go
@@ -150,9 +150,6 @@ func (r *projectPermissionResource) Create(ctx context.Context, req resource.Cre
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *projectPermissionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -189,9 +186,6 @@ func (r *projectPermissionResource) Read(ctx context.Context, req resource.ReadR
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *projectPermissionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -204,9 +198,6 @@ func (r *projectPermissionResource) Update(ctx context.Context, req resource.Upd
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *projectPermissionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/project_permissions_data_source.go
+++ b/tableau/project_permissions_data_source.go
@@ -111,9 +111,6 @@ func (d *projectPermissionsDataSource) Read(ctx context.Context, req datasource.
 	}
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *projectPermissionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/project_resource.go
+++ b/tableau/project_resource.go
@@ -127,9 +127,6 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -157,9 +154,6 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -206,9 +200,6 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/projects_data_source.go
+++ b/tableau/projects_data_source.go
@@ -95,9 +95,6 @@ func (d *projectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *projectsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/site_data_source.go
+++ b/tableau/site_data_source.go
@@ -71,9 +71,6 @@ func (d *siteDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *siteDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/site_resource.go
+++ b/tableau/site_resource.go
@@ -88,9 +88,6 @@ func (r *siteResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *siteResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -113,9 +110,6 @@ func (r *siteResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *siteResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -155,9 +149,6 @@ func (r *siteResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *siteResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/user_data_source.go
+++ b/tableau/user_data_source.go
@@ -89,9 +89,6 @@ func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *userDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/user_resource.go
+++ b/tableau/user_resource.go
@@ -138,9 +138,6 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -166,9 +163,6 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -214,9 +208,6 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/users_data_source.go
+++ b/tableau/users_data_source.go
@@ -101,9 +101,6 @@ func (d *usersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *usersDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/view_permission_resource.go
+++ b/tableau/view_permission_resource.go
@@ -159,9 +159,6 @@ func (r *viewPermissionResource) Create(ctx context.Context, req resource.Create
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *viewPermissionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -191,9 +188,6 @@ func (r *viewPermissionResource) Read(ctx context.Context, req resource.ReadRequ
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *viewPermissionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -206,9 +200,6 @@ func (r *viewPermissionResource) Update(ctx context.Context, req resource.Update
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *viewPermissionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/virtual_connection_connections_data_source.go
+++ b/tableau/virtual_connection_connections_data_source.go
@@ -103,9 +103,6 @@ func (d *virtualConnectionConnectionsDataSource) Read(ctx context.Context, req d
 	}
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *virtualConnectionConnectionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/virtual_connection_data_source.go
+++ b/tableau/virtual_connection_data_source.go
@@ -80,9 +80,6 @@ func (d *virtualConnectionDataSource) Read(ctx context.Context, req datasource.R
 	state.Name = types.StringValue(virtualConnection.Name)
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *virtualConnectionDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/virtual_connection_permission_resource.go
+++ b/tableau/virtual_connection_permission_resource.go
@@ -152,9 +152,6 @@ func (r *virtualConnectionPermissionResource) Create(ctx context.Context, req re
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *virtualConnectionPermissionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -184,9 +181,6 @@ func (r *virtualConnectionPermissionResource) Read(ctx context.Context, req reso
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *virtualConnectionPermissionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -199,9 +193,6 @@ func (r *virtualConnectionPermissionResource) Update(ctx context.Context, req re
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *virtualConnectionPermissionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/virtual_connection_revisions_data_source.go
+++ b/tableau/virtual_connection_revisions_data_source.go
@@ -104,9 +104,6 @@ func (d *virtualConnectionRevisionsDataSource) Read(ctx context.Context, req dat
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *virtualConnectionRevisionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/virtual_connections_data_source.go
+++ b/tableau/virtual_connections_data_source.go
@@ -107,9 +107,6 @@ func (d *virtualConnectionsDataSource) Read(ctx context.Context, req datasource.
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *virtualConnectionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/workbook_connections_data_source.go
+++ b/tableau/workbook_connections_data_source.go
@@ -134,9 +134,6 @@ func (d *workbookConnectionsDataSource) Read(ctx context.Context, req datasource
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *workbookConnectionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/workbook_permission_resource.go
+++ b/tableau/workbook_permission_resource.go
@@ -162,9 +162,6 @@ func (r *workbookPermissionResource) Create(ctx context.Context, req resource.Cr
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *workbookPermissionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -194,9 +191,6 @@ func (r *workbookPermissionResource) Read(ctx context.Context, req resource.Read
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *workbookPermissionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -209,9 +203,6 @@ func (r *workbookPermissionResource) Update(ctx context.Context, req resource.Up
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *workbookPermissionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/tableau/workbook_revisions_data_source.go
+++ b/tableau/workbook_revisions_data_source.go
@@ -104,9 +104,6 @@ func (d *workbookRevisionsDataSource) Read(ctx context.Context, req datasource.R
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *workbookRevisionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {

--- a/tableau/workbooks_data_source.go
+++ b/tableau/workbooks_data_source.go
@@ -163,9 +163,6 @@ func (d *workbooksDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *workbooksDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {


### PR DESCRIPTION
If we have
```
	if resp.Diagnostics.HasError() {
		return
	}
```
at the end of `func`, it doesn't do anything useful.